### PR TITLE
Fix autoload.php path when using Composer global

### DIFF
--- a/dependency-graph
+++ b/dependency-graph
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 $paths = [
     __DIR__.'/vendor/autoload.php',
-    __DIR__ . '/../../vendor/autoload.php',
+    __DIR__ . '/../../../vendor/autoload.php',
 ];
 
 foreach ($paths as $file) {

--- a/tests/Loader/DependentsTest.php
+++ b/tests/Loader/DependentsTest.php
@@ -34,6 +34,6 @@ class DependentsTest extends TestCase
 
         $this->assertInstanceOf(SetInterface::class, $packages);
         $this->assertSame(PackageModel::class, (string) $packages->type());
-        $this->assertCount(53, $packages);
+        $this->assertCount(54, $packages);
     }
 }

--- a/tests/Loader/VendorTest.php
+++ b/tests/Loader/VendorTest.php
@@ -22,6 +22,6 @@ class VendorTest extends TestCase
 
         $this->assertInstanceOf(Model::class, $vendor);
         $this->assertSame('innmind', (string) $vendor->name());
-        $this->assertCount(59, $vendor);
+        $this->assertCount(60, $vendor);
     }
 }


### PR DESCRIPTION
The path to the `autoload.php` file is wrong when using `composer global require`.