### PR TITLE
Fix out of memory error due to circular dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Circular dependency crashing the `of` command by memory exhaustion
+
 ## 3.7.0 - 2024-07-28
 
 ### Added

--- a/tests/Loader/DependenciesTest.php
+++ b/tests/Loader/DependenciesTest.php
@@ -81,4 +81,16 @@ DOT;
         $this->assertInstanceOf(Set::class, $packages);
         $this->assertCount(25, $packages);
     }
+
+    public function testCircularDependencyRegression()
+    {
+        $load = new Dependencies(
+            new Package(Curl::of(new Clock)->maxConcurrency(20)),
+        );
+
+        $packages = $load(PackageModel\Name::of('laravel/browser-kit-testing'));
+
+        $this->assertInstanceOf(Set::class, $packages);
+        $this->assertCount(106, $packages);
+    }
 }


### PR DESCRIPTION
## Problem

When trying to render the dependencies of `laravel/browser-kit-testing` it crashes due to `league/flysystem` and `league/flysystem-local` being circular dependent.

## Solution

Check if a package is already being fetched in the dependency tree to prevent infinite recursion.

## Note

How is it even possible to declare circular dependent packages ?!