### PR TITLE
Fix out of memory error due to circular dependency in dependents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Circular dependency crashing the `depends-on` command by memory exhaustion
+
 ## 3.7.1 - 2024-07-28
 
 ### Fixed

--- a/src/Loader/Dependents/Graph.php
+++ b/src/Loader/Dependents/Graph.php
@@ -50,6 +50,7 @@ final class Graph
         return $package->relations()->any(
             static fn($relation) => $packages
                 ->find(static fn($package) => $package->name()->equals($relation->name()))
+                ->filter(static fn($relation) => !$relation->dependsOn($package->name()))
                 ->match(
                     static fn($package) => self::dependsOn($root, $package, $packages),
                     static fn() => false,

--- a/tests/Loader/DependentsTest.php
+++ b/tests/Loader/DependentsTest.php
@@ -121,4 +121,23 @@ class DependentsTest extends TestCase
                 ->toList(),
         );
     }
+    public function testCircularDependencyRegression()
+    {
+        $http = Curl::of(new Clock)->maxConcurrency(20);
+
+        $load = new Dependents(
+            new Vendor(
+                $http,
+                new Package($http),
+            ),
+        );
+
+        $packages = $load(
+            PackageModel\Name::of('league/climate'),
+            Set::of(VendorModel\Name::of('league')),
+        );
+
+        $this->assertInstanceOf(Set::class, $packages);
+        $this->assertCount(1, $packages);
+    }
 }


### PR DESCRIPTION
Same as #5 but for dependents graph