### PR TITLE
Fix opened files exhaustion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": "~8.2",
-        "innmind/immutable": "~5.2",
+        "innmind/immutable": "~5.9",
         "innmind/url": "~4.1",
         "innmind/operating-system": "~4.1|~5.0",
         "innmind/json": "^1.1",

--- a/tests/Loader/VendorTest.php
+++ b/tests/Loader/VendorTest.php
@@ -115,4 +115,15 @@ class VendorTest extends TestCase
                 ->toList(),
         );
     }
+
+    public function testMaxOpenedFilesRegression()
+    {
+        $http = Curl::of(new Clock)->maxConcurrency(20);
+        $load = new Vendor($http, new Package($http));
+
+        $vendor = $load(Model\Name::of('symfony'));
+
+        $this->assertInstanceOf(Model::class, $vendor);
+        $this->assertCount(247, $vendor->packages());
+    }
 }


### PR DESCRIPTION
## Problem

When loading the vendor packages it may exhaust the maximum allowed number of opened files. This is the case if the number of packages is close to this number (this is the case for Symfony). 

The problem lies in the laziness to fetch the packages detail as it allows concurrent calls. Even though the concurrency is capped it still keeps the responses body opened until accessing the first response to translate it to the detail object.

## Solution

We chunk the list of packages by `100`. For each of them we plan the request, then when all `100` are planned we extract them via a combo of `flatMap(Maybe->toSequence())`. The outer `flatMap` transforms the chunks of `100` packages into a single `Sequence`.

The `100` number has been chosen to be below the half of the max opened files on a macbook pro m1 (`256`) and a multiple of the max concurrency (`20`).